### PR TITLE
Started implementing the distant sensor parametrizable target area

### DIFF
--- a/src/sensors/distant.cpp
+++ b/src/sensors/distant.cpp
@@ -9,10 +9,11 @@
 
 NAMESPACE_BEGIN(mitsuba)
 
-enum class RayOriginType {Distant, Rectangle, Disk};
+enum class RayTargetType {Distant, Rectangle, Disk};
+enum class RayOriginType {Shape, Rectangle, Disk};
 
 // Forward declaration of specialized DistantSensor
-template <typename Float, typename Spectrum, RayOriginType OriginType>
+template <typename Float, typename Spectrum, RayTargetType TargetType>
 class DistantSensorImpl;
 
 /**!
@@ -31,28 +32,28 @@ Distant directional sensor (:monosp:`distant`)
    - |vector|
    - Alternative (and exclusive) to `to_world`. Direction from which the
      sensor will be recording in world coordinates.
- * - ray_origin_type
+ * - ray_target_type
    - |string|
-   - *Optional.* Specify the ray origin sampling strategy. 
-     If set to ``"rectangle"``, ray origins will be sampled uniformly from 
+   - *Optional.* Specify the ray target sampling strategy. 
+     If set to ``"rectangle"``, ray targets will be sampled uniformly from 
      a xy-plane-aligned rectangular surface defined by the parameters 
-     ``ray_origin_a`` and `` ray_origin_b``. If set to ``"disk"``, ray rigins will
+     ``ray_target_a`` and `` ray_target_b``. If set to ``"disk"``, ray targets will
      be sampled uniformly from a xy-plane-aligned disk defined by the parameters 
-     ``ray_origin_center`` and ``ray_origin_radius``. If set to ``"distant"``, ray origins 
+     ``ray_target_center`` and ``ray_target_radius``. If set to ``"distant"``, ray targets 
      will be sampled to uniformly cover the entire scene and will be positioned 
      on a bounding sphere. Default: ``"distant"``.
- * - ray_origin_a
+ * - ray_target_a
    - |point|
-   - Coordinates in the xy-plane for the rectangular ray origin area.
- * - ray_origin_b
+   - Coordinates in the xy-plane for the rectangular ray target area.
+ * - ray_target_b
    - |point|
-   - Maximum coordinates in the xy-plane for the rectangular ray origin area.
- * - ray_origin_center
+   - Maximum coordinates in the xy-plane for the rectangular ray target area.
+ * - ray_target_center
    - |point|
-   - Center point in the xy-plane for the circular ray origin area.
- * - ray_origin_radius
+   - Center point in the xy-plane for the circular ray target area.
+ * - ray_target_radius
    - |float|
-   - Radius for the circular ray origin area
+   - Radius for the circular ray target area
     
 
 This sensor plugin implements a distant directional sensor which records
@@ -68,15 +69,15 @@ distributed uniformly on the cross section of the scene's bounding sphere.
     bounding sphere cross section. Care should be taken notably when using the
     `constant` or `envmap` emitters.
 
-With the ``ray_origin_*`` parameters users can define an area parallel to the xy-plane
-that the sensor's rays will originate from. The area can be defined in two ways:
+With the ``ray_target_*`` parameters users can define an area parallel to the xy-plane
+that the sensor's rays will target. The area can be defined in two ways:
 
-- Setting `ray_origin_type` to 'rectangle' lets users define a rectangular area through 
-  two points `ray_origin_a` and `ray_origin_b`. The resulting area will cover the area 
+- Setting `ray_target_type` to 'rectangle' lets users define a rectangular area through 
+  two points `ray_target_a` and `ray_target_b`. The resulting area will cover the area 
   from the smaller to the larger value in both dimensions.
-- Setting `ray_origin_type` to 'circle'  lets users define a circular ray_origin area 
-  through a center `ray_origin_center` and a radius `ray_origin_radius`.
-- If `ray_origin_type` is not set, the sensor will ray_origin the entire cross section
+- Setting `ray_target_type` to 'circle'  lets users define a circular ray_target area 
+  through a center `ray_target_center` and a radius `ray_target_radius`.
+- If `ray_target_type` is not set, the sensor will target the entire cross section
   of the scene's bounding sphere.
 
 */
@@ -89,47 +90,56 @@ public:
 
     DistantSensor(const Properties &props) : Base(props), m_props(props) {
 
-        std::string ray_origin_type = props.string("ray_origin_type", "distant");
+        std::string ray_target_type = props.string("ray_target_type", "distant");
 
-        if (ray_origin_type == "rectangle") {
-            m_ray_origin_type = RayOriginType::Rectangle;
-        } else if (ray_origin_type == "disk") {
-            m_ray_origin_type = RayOriginType::Disk;
-        } else if (ray_origin_type == "distant") {
-            m_ray_origin_type = RayOriginType::Distant;
+        // ray target type to set the templated variant in
+        // DistantSensorImpl
+        if (ray_target_type == "rectangle") {
+            m_ray_target_type = RayTargetType::Rectangle;
+        } else if (ray_target_type == "disk") {
+            m_ray_target_type = RayTargetType::Disk;
+        } else if (ray_target_type == "distant") {
+            m_ray_target_type = RayTargetType::Distant;
         } else {
-            Throw("Unsupported ray origin type!");
+            Throw("Unsupported ray target type!");
         }
 
-        props.mark_queried("ray_origin_center");
-        props.mark_queried("ray_origin_radius");
-        props.mark_queried("ray_origin_a");
-        props.mark_queried("ray_origin_b");
+        props.mark_queried("ray_target_center");
+        props.mark_queried("ray_target_radius");
+        props.mark_queried("ray_target_a");
+        props.mark_queried("ray_target_b");
         props.mark_queried("direction");
         props.mark_queried("to_world");
+
+        props.mark_queried("ray_origin_radius");
+        props.mark_queried("ray_origin_center");
+        props.mark_queried("ray_origin_a");
+        props.mark_queried("ray_origin_b");
+        props.mark_queried("ray_origin_shape");
+        props.mark_queried("ray_origin_type");
     }
 
     /// This sensor does not occupy any particular region of space, return an
     /// invalid bounding box
     ScalarBoundingBox3f bbox() const override { return ScalarBoundingBox3f(); }
 
-    template <RayOriginType OriginType>
-    using Impl = DistantSensorImpl<Float, Spectrum, OriginType>;
+    template <RayTargetType TargetType>
+    using Impl = DistantSensorImpl<Float, Spectrum, TargetType>;
 
     /**
      * Recursively expand into an implementation specialized to the ray origin specification.
      */
     std::vector<ref<Object>> expand() const override {
         ref<Object> result;
-        switch (m_ray_origin_type) {
-            case RayOriginType::Disk:
-                result = (Object *) new Impl<RayOriginType::Disk>(m_props);
+        switch (m_ray_target_type) {
+            case RayTargetType::Disk:
+                result = (Object *) new Impl<RayTargetType::Disk>(m_props);
                 break;
-            case RayOriginType::Rectangle:
-                result = (Object *) new Impl<RayOriginType::Rectangle>(m_props);
+            case RayTargetType::Rectangle:
+                result = (Object *) new Impl<RayTargetType::Rectangle>(m_props);
                 break;
-            case RayOriginType::Distant:
-                result = (Object *) new Impl<RayOriginType::Distant>(m_props);
+            case RayTargetType::Distant:
+                result = (Object *) new Impl<RayTargetType::Distant>(m_props);
                 break;
             default:
                 Throw("Unsupported ray origin type!");
@@ -141,10 +151,10 @@ public:
 
 protected:
     Properties m_props;
-    RayOriginType m_ray_origin_type;
+    RayTargetType m_ray_target_type;
 };
 
-template <typename Float, typename Spectrum, RayOriginType OriginType>
+template <typename Float, typename Spectrum, RayTargetType TargetType>
 class DistantSensorImpl final : public Sensor<Float, Spectrum> {
 public:
     MTS_IMPORT_BASE(Sensor, m_world_transform, m_film)
@@ -165,27 +175,60 @@ public:
                     ScalarPoint3f(0.0f), ScalarPoint3f(direction), up));
         }
 
-        if constexpr (OriginType == RayOriginType::Disk) {
-            if (!props.has_property("ray_origin_center") || !props.has_property("ray_origin_radius")) {
-                Throw("RayOriginType::Disk requires the 'm_ray_origin_center' and 'm_ray_origin_radius' parameters");
+        if constexpr (TargetType == RayTargetType::Disk) {
+            if (!props.has_property("ray_target_center") || !props.has_property("ray_target_radius")) {
+                Throw("RayTargetType::Disk requires the 'm_ray_target_center' and 'm_ray_target_radius' parameters");
             }
-            m_ray_origin_center = props.point3f("ray_origin_center");
-            m_ray_origin_radius = props.float_("ray_origin_radius");
-        } else if constexpr (OriginType == RayOriginType::Rectangle) {
-            if (!props.has_property("ray_origin_a") || !props.has_property("ray_origin_b")) {
-                Throw("RayOriginType::Rectangle requires the 'm_ray_origin_a' and 'm_ray_origin_b' parameters");
+            m_ray_target_center = props.point3f("ray_target_center");
+            m_ray_target_radius = props.float_("ray_target_radius");
+        } else if constexpr (TargetType == RayTargetType::Rectangle) {
+            if (!props.has_property("ray_target_a") || !props.has_property("ray_target_b")) {
+                Throw("RayTargetType::Rectangle requires the 'm_ray_target_a' and 'm_ray_target_b' parameters");
             }
-            if (!(m_ray_origin_a.z() == m_ray_origin_b.z())) {
-                Throw("z-components of m_ray_origin_a and m_ray_origin_b do not match. "
-                      "Cannot determine ray_origin zone elevation.");
+            m_ray_target_a = props.point3f("ray_target_a");
+            m_ray_target_b = props.point3f("ray_target_b");
+            if (!(m_ray_target_a.z() == m_ray_target_b.z())) {
+                Throw("z-components of m_ray_target_a and m_ray_target_b do not match. "
+                      "%s, %s", m_ray_target_a, m_ray_target_b);
             }
-            m_ray_origin_a = props.point3f("ray_origin_a");
-            m_ray_origin_b = props.point3f("ray_origin_b");
-        } else if constexpr (OriginType == RayOriginType::Distant) {
+        } else if constexpr (TargetType == RayTargetType::Distant) {
 
         } else {
-            NotImplementedError("Unsupported RayOriginType");
+            NotImplementedError("Unsupported RayTargetType");
         }
+        
+        std::string origin_type = props.string("ray_origin_type", "disk");
+
+        // set ray origin type for ray validity checks
+        if (origin_type == "disk") {
+            m_ray_origin_type = RayOriginType::Disk;
+        } else if (origin_type == "rectangle") {
+            m_ray_origin_type = RayOriginType::Rectangle;
+        } else if (origin_type == "shape") {
+            m_ray_origin_type = RayOriginType::Shape
+        } else {
+            Throw("Unknown ray origin type: %s", origin_type);
+        }
+
+        if (m_ray_origin_type == RayOriginType::Disk) {
+            m_ray_origin_center = props.point3f("ray_origin_center");
+            m_ray_origin_radius = props.float_("ray_origin_radius");
+        } else if (m_ray_origin_type == RayOriginType::Rectangle) {
+            m_ray_origin_a      = props.point3f("ray_origin_a");
+            m_ray_origin_b      = props.point3f("ray_origin_b");
+        } else if (m_ray_origin_type == RayOriginType::Shape) {
+            for (auto &[name, obj] : props.objects(false)) {
+                ray_origin_shape = dynamic_cast<Shape * >(obj.get());
+
+                if (ray_origin_shape)
+                    m_ray_origin_shape = ray_origin_shape;
+                    props.mark_queried("ray_origin_shape")
+            }
+            if (!m_ray_origin_shape){
+                Throw("Could not instantiate a shape for ray origins.");
+            }
+        }
+
 
         if (m_film->size() != ScalarPoint2i(1, 1))
             Throw("This sensor only supports films of size 1x1 Pixels!");
@@ -195,7 +238,7 @@ public:
             Log(Warn, "This sensor should be used with a reconstruction filter "
                       "with a radius of 0.5 or lower (e.g. default box)");
 
-        props.mark_queried("ray_origin");
+        props.mark_queried("ray_target");
         props.mark_queried("direction");
         props.mark_queried("to_world");
 
@@ -206,14 +249,14 @@ public:
         m_bsphere.radius =
             max(math::RayEpsilon<Float>,
                 m_bsphere.radius * (1.f + math::RayEpsilon<Float>) );
-        if constexpr (OriginType == RayOriginType::Distant) {
-            m_ray_origin_area = math::Pi<Float> * sqr(m_bsphere.radius);
-        } else if constexpr (OriginType == RayOriginType::Disk) {
-            m_ray_origin_area = math::Pi<Float> * sqr(m_ray_origin_radius);
-        } else if constexpr (OriginType == RayOriginType::Rectangle) {
-            m_ray_origin_area = abs(m_ray_origin_b.x()-m_ray_origin_a.x()) * abs(m_ray_origin_b.y()-m_ray_origin_a.y());
+        if constexpr (TargetType == RayTargetType::Distant) {
+            m_ray_target_area = math::Pi<Float> * sqr(m_bsphere.radius);
+        } else if constexpr (TargetType == RayTargetType::Disk) {
+            m_ray_target_area = math::Pi<Float> * sqr(m_ray_target_radius);
+        } else if constexpr (TargetType == RayTargetType::Rectangle) {
+            m_ray_target_area = abs(m_ray_target_b.x()-m_ray_target_a.x()) * abs(m_ray_target_b.y()-m_ray_target_a.y());
         } else {
-            NotImplementedError("Unsupported RayOriginType");
+            NotImplementedError("Unsupported RayTargetType");
         }
 
         // rays must begin outside of the bounding box
@@ -223,8 +266,42 @@ public:
         auto trafo          = m_world_transform->eval(0.f, true);
         Vector3f direction  = -trafo.transform_affine(Vector3f{ 0.f, 0.f, 1.f });
         Float bbox_zmax     = scene->bbox().max.z() * 1.1f;
-        m_ray_origin_length = bbox_zmax / direction.z();
+        m_ray_target_length = bbox_zmax / direction.z();
+        if (m_ray_target_length == 0){
+            m_ray_target_length = 0.1f;
+        }
     }
+
+    bool validate_ray(Point3f ray_target, Vector3f ray_direction) {
+        if (m_ray_origin_type == RayTargetType::Disk) {
+                Float ray_valid_distance = abs(m_ray_origin_center.z() / ray_direction.z());
+                Point3f ray_valid_point = ray_target - ray_direction * ray_valid_distance;
+                if (sqrt(sqr(ray_valid_point.x()) + sqr(ray_valid_point.y())) > m_ray_origin_radius){
+                    return false
+                } else { return true }
+        } else if (m_ray_origin_type == RayTargetType::Rectangle) {
+            Float ray_valid_distance = abs(m_ray_origin_a.z() / ray_direction.z());
+            Point3f ray_valid_point = ray_target - ray_direction * ray_valid_distance;
+            if (ray_valid_point.x() < min(m_ray_origin_a.x(), m_ray_origin_b.x()) or
+                ray_valid_point.x() > max(m_ray_origin_a.x(), m_ray_origin_b.x()) or
+                ray_valid_point.y() < min(m_ray_origin_a.y(), m_ray_origin_b.y()) or
+                ray_valid_point.y() > max(m_ray_origin_a.y(), m_ray_origin_b.y())) {
+                    return false
+                } else { return true }
+        } else if (m_ray_origin_type == RayOriginType::Shape) {
+            Ray3f test_ray;
+            test_ray.time = 0.f;
+            test_ray.o = ray_target;
+            test_ray.d = -ray_direction;
+            if (!m_ray_origin_shape->ray_test(test_ray, true)){
+                return false
+            } else {return true}
+        } else {
+            Throw("Unsupported ray origin type: %s", m_ray_origin_type);
+            return false
+        }
+    }
+    // won't compile. why? :O
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
                                           const Point2f & /*film_sample*/,
@@ -246,7 +323,7 @@ public:
         // 3. Sample ray origin
         Spectrum ray_weight = 0.f;
 
-        if constexpr (OriginType == RayOriginType::Distant) {
+        if constexpr (TargetType == RayTargetType::Distant) {
             // If no ray origin is defined, sample a target point on the
             // bounding sphere's cross section
             Point2f offset =
@@ -254,23 +331,34 @@ public:
             Vector3f perp_offset =
                 trafo.transform_affine(Vector3f{ offset.x(), offset.y(), 0.f });
             Point3f ray_target = m_bsphere.center + perp_offset * m_bsphere.radius;
-            ray.o = ray_target - ray.d * m_ray_origin_length;
-            ray_weight = wav_weight * m_ray_origin_area;
+            ray.o = ray_target - ray.d * m_ray_target_length;
+            ray_weight = wav_weight * m_ray_target_area;
+
+            if (!validate_ray(ray_target, ray.d)) {
+                Throw("Invalid ray origin!");
+            }
         } 
-        if constexpr (OriginType == RayOriginType::Rectangle) {
-            Float ray_origin_x = abs(m_ray_origin_b.x() - m_ray_origin_a.x()) * aperture_sample.x() + min(m_ray_origin_a.x(), m_ray_origin_b.x());
-            Float ray_origin_y = abs(m_ray_origin_b.y() - m_ray_origin_a.y()) * aperture_sample.y() + min(m_ray_origin_a.y(), m_ray_origin_b.y());
-            Point3f ray_target = Point3f{ray_origin_x, ray_origin_y, m_ray_origin_a.z()};
-            ray.o = ray_target - ray.d * m_ray_origin_length;
-            ray_weight = wav_weight * m_ray_origin_area * Frame3f::cos_theta(-ray.d);
-        }
-        if constexpr (OriginType == RayOriginType::Disk) {
-            Point2f disk_sample = Point2f(warp::square_to_uniform_disk(aperture_sample)) * m_ray_origin_radius;
-            Point3f sample_disk = Point3f(disk_sample.x(), disk_sample.y(), 0.f) + m_ray_origin_center;
-            Point3f ray_target = Point3f{sample_disk.x(), sample_disk.y(), m_ray_origin_center.z()};
-            ray.o = ray_target - ray.d * m_ray_origin_length;
-            // Log(Warn, "Ray origin: %s", ray.o);
+        if constexpr (TargetType == RayTargetType::Rectangle) {
+            Float ray_target_x = abs(m_ray_target_b.x() - m_ray_target_a.x()) * aperture_sample.x() + min(m_ray_target_a.x(), m_ray_target_b.x());
+            Float ray_target_y = abs(m_ray_target_b.y() - m_ray_target_a.y()) * aperture_sample.y() + min(m_ray_target_a.y(), m_ray_target_b.y());
+            Point3f ray_target = Point3f{ray_target_x, ray_target_y, m_ray_target_a.z()};
+            ray.o = ray_target - ray.d * m_ray_target_length;
+            ray_weight = wav_weight * m_ray_target_area * Frame3f::cos_theta(-ray.d);
+
+            if (!validate_ray(ray_target, ray.d)) {
+                Throw("Invalid ray origin!");
+            }
+        }   
+        if constexpr (TargetType == RayTargetType::Disk) {
+            Point2f disk_sample = Point2f(warp::square_to_uniform_disk(aperture_sample)) * m_ray_target_radius;
+            Point3f sample_disk = Point3f(disk_sample.x(), disk_sample.y(), 0.f) + m_ray_target_center;
+            Point3f ray_target = Point3f{sample_disk.x(), sample_disk.y(), m_ray_target_center.z()};
+            ray.o = ray_target - ray.d * m_ray_target_length;
             ray_weight = wav_weight * 1 * Frame3f::cos_theta(-ray.d);
+            
+            if (!validate_ray(ray_target, ray.d)) {
+                Throw("Invalid ray origin!");
+            }
         }
 
         ray.update();
@@ -296,7 +384,7 @@ public:
         // 3. Sample ray origin
         Spectrum ray_weight = 0.f;
 
-        if constexpr (OriginType == RayOriginType::Distant) {
+        if constexpr (TargetType == RayTargetType::Distant) {
             // If no ray origin is defined, sample a target point on the
             // bounding sphere's cross section
             Point2f offset =
@@ -304,22 +392,33 @@ public:
             Vector3f perp_offset =
                 trafo.transform_affine(Vector3f{ offset.x(), offset.y(), 0.f });
             Point3f ray_target = m_bsphere.center + perp_offset * m_bsphere.radius;
-            ray.o = ray_target - ray.d * m_ray_origin_length;
-            ray_weight = wav_weight * m_ray_origin_area;
+            ray.o = ray_target - ray.d * m_ray_target_length;
+            ray_weight = wav_weight * m_ray_target_area;
+
+            if (!validate_ray(ray_target, ray.d)) {
+                Throw("Invalid ray origin!");
+            }
         } 
-        if constexpr (OriginType == RayOriginType::Rectangle) {
-            Float ray_origin_x = abs(m_ray_origin_b.x() - m_ray_origin_a.x()) * aperture_sample.x() + min(m_ray_origin_a.x(), m_ray_origin_b.x());
-            Float ray_origin_y = abs(m_ray_origin_b.y() - m_ray_origin_a.y()) * aperture_sample.y() + min(m_ray_origin_a.y(), m_ray_origin_b.y());
-            Point3f ray_target = Point3f{ray_origin_x, ray_origin_y, m_ray_origin_a.z()};
-            ray.o = ray_target - ray.d * m_ray_origin_length;
-            ray_weight = wav_weight * m_ray_origin_area * Frame3f::cos_theta(-ray.d);
+        if constexpr (TargetType == RayTargetType::Rectangle) {
+            Float ray_target_x = abs(m_ray_target_b.x() - m_ray_target_a.x()) * aperture_sample.x() + min(m_ray_target_a.x(), m_ray_target_b.x());
+            Float ray_target_y = abs(m_ray_target_b.y() - m_ray_target_a.y()) * aperture_sample.y() + min(m_ray_target_a.y(), m_ray_target_b.y());
+            Point3f ray_target = Point3f{ray_target_x, ray_target_y, m_ray_target_a.z()};
+            ray.o = ray_target - ray.d * m_ray_target_length;
+            ray_weight = wav_weight * m_ray_target_area * Frame3f::cos_theta(-ray.d);
+
+            if (!validate_ray(ray_target, ray.d)) {
+                Throw("Invalid ray origin!");
+            }
         }
-        if constexpr (OriginType == RayOriginType::Disk) {
-            Point2f disk_sample = Point2f(warp::square_to_uniform_disk(aperture_sample)) * m_ray_origin_radius;
-            Point3f ray_target = Point3f(disk_sample.x(), disk_sample.y(), 0.f) + m_ray_origin_center;
-            ray.o = ray_target - ray.d * m_ray_origin_length;
-            // Log(Warn, "Ray origin: %s", ray.o);
+        if constexpr (TargetType == RayTargetType::Disk) {
+            Point2f disk_sample = Point2f(warp::square_to_uniform_disk(aperture_sample)) * m_ray_target_radius;
+            Point3f ray_target = Point3f(disk_sample.x(), disk_sample.y(), 0.f) + m_ray_target_center;
+            ray.o = ray_target - ray.d * m_ray_target_length;
             ray_weight = wav_weight * 1 * Frame3f::cos_theta(-ray.d);
+
+            if (!validate_ray(ray_target, ray.d)) {
+                Throw("Invalid ray origin!");
+            }
         }
         
         // 4. Set differentials; since the film size is always 1x1, we don't
@@ -336,28 +435,28 @@ public:
 
     std::string to_string() const override {
         std::ostringstream oss;
-        if constexpr (OriginType == RayOriginType::Rectangle) {
+        if constexpr (TargetType == RayTargetType::Rectangle) {
             oss << "DistantSensor[" << std::endl
                 << "  world_transform = " << m_world_transform << "," << std::endl
-                << "  ray_origin_type = " << "rectangle" << "," << std::endl
-                << "  ray_origin_point_a = " << m_ray_origin_a << "," << std::endl
-                << "  ray_origin_point_b = " << m_ray_origin_b << "," << std::endl
+                << "  ray_target_type = " << "rectangle" << "," << std::endl
+                << "  ray_target_point_a = " << m_ray_target_a << "," << std::endl
+                << "  ray_target_point_b = " << m_ray_target_b << "," << std::endl
                 << "  film = " << m_film << "," << std::endl
                 << "]";
             return oss.str();
-        } else if constexpr (OriginType == RayOriginType::Disk) {
+        } else if constexpr (TargetType == RayTargetType::Disk) {
             oss << "DistantSensor[" << std::endl
                 << "  world_transform = " << m_world_transform << "," << std::endl
-                << "  ray_origin_type = " << "disk" << "," << std::endl
-                << "  ray_origin_center = " << m_ray_origin_center << "," << std::endl
-                << "  ray_origin_point_radius = " << m_ray_origin_radius << "," << std::endl
+                << "  ray_target_type = " << "disk" << "," << std::endl
+                << "  ray_target_center = " << m_ray_target_center << "," << std::endl
+                << "  ray_target_point_radius = " << m_ray_target_radius << "," << std::endl
                 << "  film = " << m_film << "," << std::endl
                 << "]";
             return oss.str();
-        } else if constexpr (OriginType == RayOriginType::Distant) {
+        } else if constexpr (TargetType == RayTargetType::Distant) {
             oss << "DistantSensor[" << std::endl
                 << "  world_transform = " << m_world_transform << "," << std::endl
-                << "  ray_origin_type = " << "distant" << "," << std::endl
+                << "  ray_target_type = " << "distant" << "," << std::endl
                 << "  bsphere = " << m_bsphere << "," << std::endl
                 << "  film = " << m_film << "," << std::endl
                 << "]";
@@ -371,36 +470,44 @@ public:
 
 protected:
     ScalarBoundingSphere3f m_bsphere;
+    Point3f m_ray_target_center;
+    Float m_ray_target_radius;
+    Point3f m_ray_target_a;
+    Point3f m_ray_target_b;
+    Float m_ray_target_area;
+    Float m_ray_target_length;
+
+    
     Point3f m_ray_origin_center;
     Float m_ray_origin_radius;
     Point3f m_ray_origin_a;
     Point3f m_ray_origin_b;
-    Float m_ray_origin_area;
-    Float m_ray_origin_length;
+    RayTargetType m_ray_origin_type;
+    Shape *m_origin_shape;
 };
 
 MTS_IMPLEMENT_CLASS_VARIANT(DistantSensor, Sensor)
 MTS_EXPORT_PLUGIN(DistantSensor, "DistantSensor")
 
 NAMESPACE_BEGIN(detail)
-template <RayOriginType OriginType> constexpr const char *distant_sensor_class_name() {
-    if constexpr (OriginType == RayOriginType::Disk) {
+template <RayTargetType TargetType> constexpr const char *distant_sensor_class_name() {
+    if constexpr (TargetType == RayTargetType::Disk) {
         return "DistantSensor_Disk";
-    } else if constexpr (OriginType == RayOriginType::Rectangle) {
+    } else if constexpr (TargetType == RayTargetType::Rectangle) {
         return "DistantSensor_Rectangle";
-    } else if constexpr (OriginType == RayOriginType::Distant) {
+    } else if constexpr (TargetType == RayTargetType::Distant) {
         return "DistantSensor_Distant";
     }
 }
 NAMESPACE_END(detail)
 
-template <typename Float, typename Spectrum, RayOriginType OriginType>
-Class *DistantSensorImpl<Float, Spectrum, OriginType>::m_class = new Class(
-    detail::distant_sensor_class_name<OriginType>(), "Sensor",
+template <typename Float, typename Spectrum, RayTargetType TargetType>
+Class *DistantSensorImpl<Float, Spectrum, TargetType>::m_class = new Class(
+    detail::distant_sensor_class_name<TargetType>(), "Sensor",
     ::mitsuba::detail::get_variant<Float, Spectrum>(), nullptr, nullptr);
 
-template <typename Float, typename Spectrum, RayOriginType OriginType>
-const Class *DistantSensorImpl<Float, Spectrum, OriginType>::class_() const {
+template <typename Float, typename Spectrum, RayTargetType TargetType>
+const Class *DistantSensorImpl<Float, Spectrum, TargetType>::class_() const {
     return m_class;
 }
 

--- a/src/sensors/distant.cpp
+++ b/src/sensors/distant.cpp
@@ -170,17 +170,17 @@ public:
 
         if constexpr (OriginType == RayOriginType::Disk) {
             if (!props.has_property("ray_origin_center") || !props.has_property("ray_origin_radius")) {
-                Throw("Circular ray_origin requires the 'ray_origin_center' and 'ray_origin_radius' parameters");
+                Throw("RayOriginType::Disk requires the 'm_ray_origin_center' and 'm_ray_origin_radius' parameters");
             }
             m_ray_origin_center = props.point3f("ray_origin_center");
             m_ray_origin_radius = props.float_("ray_origin_radius");
             m_ray_origin_area = math::Pi<Float> * sqr(m_ray_origin_radius);
         } else if constexpr (OriginType == RayOriginType::Rectangle) {
             if (!props.has_property("ray_origin_a") || !props.has_property("ray_origin_b")) {
-                Throw("Rectangular ray_origin requires the 'ray_origin_a' and 'ray_origin_b' parameters");
+                Throw("RayOriginType::Rectangle requires the 'm_ray_origin_a' and 'm_ray_origin_b' parameters");
             }
             if (!(m_ray_origin_a.z() == m_ray_origin_b.z())) {
-                Throw("z-components of ray_origin_a and ray_origin_b do not match. "
+                Throw("z-components of m_ray_origin_a and m_ray_origin_b do not match. "
                       "Cannot determine ray_origin zone elevation.");
             }
             m_ray_origin_a = props.point3f("ray_origin_a");

--- a/src/sensors/tests/test_distant.py
+++ b/src/sensors/tests/test_distant.py
@@ -12,12 +12,12 @@ def dict_sensor(direction=None,
                 origin_a=[0,0,0],
                 origin_b=[0,0,0],
                 fwidth=1):
-    result = {"type": "distant", "origin": "circle", "origin_radius": 0, "origin_center": [0,0,0]}
+    result = {"type": "distant", "origin": "disk", "origin_radius": 0, "origin_center": [0,0,0]}
 
     if direction:
         result["direction"] = direction
 
-    if origin_type == "circle":
+    if origin_type == "disk":
         result["origin"] = origin_type
         result["origin_center"] = origin_center
         result["origin_radius"] = origin_radius
@@ -79,8 +79,8 @@ def test_construct(variant_scalar_rgb):
 
 @pytest.mark.parametrize("origin", [
     {"origin_type": None},
-    {"origin_type": "circle", "origin_radius": 0, "origin_center": [0.0, 0.0, 0.0]},
-    {"origin_type": "circle", "origin_radius": 0.5, "origin_center": [4.0, 1.0, 0.0]},
+    {"origin_type": "disk", "origin_radius": 0, "origin_center": [0.0, 0.0, 0.0]},
+    {"origin_type": "disk", "origin_radius": 0.5, "origin_center": [4.0, 1.0, 0.0]},
     {"origin_type": "rectangle", "origin_a": [0,0,0], "origin_b": [0,0,0]},
     {"origin_type": "rectangle", "origin_a": [-1,-1,0], "origin_b": [1,1,0]}
 ])
@@ -126,8 +126,8 @@ def make_scene(**kwargs):
 @pytest.mark.parametrize("origin", [
     {"origin_type": "rectangle", "origin_a": [-1,-1,1], "origin_b": [1,1,1], "expected_invalid":0.},
     {"origin_type": "rectangle", "origin_a": [-2,-2,2], "origin_b": [2,2,2], "expected_invalid":0.75},
-    {"origin_type": "circle", "origin_center": [0,0,1], "origin_radius": 1, "expected_invalid": 0},
-    {"origin_type": "circle", "origin_center": [0,0,2], "origin_radius": 2, "expected_invalid": 0.6816}
+    {"origin_type": "disk", "origin_center": [0,0,1], "origin_radius": 1, "expected_invalid": 0},
+    {"origin_type": "disk", "origin_center": [0,0,2], "origin_radius": 2, "expected_invalid": 0.6816}
 ])
 def test_origin_area(variant_scalar_rgb, origin):
     """Test if the sensor correctly targets the expected area by computing
@@ -157,7 +157,7 @@ def test_origin_area(variant_scalar_rgb, origin):
         
     # Average intersection locations should be (in average) centered
     # around the origin specified
-    if origin["origin_type"] == "circle":
+    if origin["origin_type"] == "disk":
         center = origin["origin_center"]
     elif origin["origin_type"] == "rectangle":
         center = (np.array(origin["origin_b"]) + np.array(origin["origin_a"])) / 2.
@@ -180,7 +180,7 @@ def test_origin_area(variant_scalar_rgb, origin):
 @pytest.mark.parametrize("w_o", [[0, 0, -1], [0, 1, -1]])
 @pytest.mark.parametrize("origin", [
     {},
-    {"origin": "circle", "origin_center": [0,0,2], "origin_radius": 1},
+    {"origin": "disk", "origin_center": [0,0,2], "origin_radius": 1},
     {"origin": "rectangle", "origin_a": [-1,-1,2], "origin_b": [1,1,2]}
 ])
 def test_render(variant_scalar_rgb, w_e, w_o, origin):

--- a/src/sensors/tests/test_distant.py
+++ b/src/sensors/tests/test_distant.py
@@ -40,7 +40,7 @@ def make_sensor(**kwargs):
     from mitsuba.core.xml import load_dict
     sensor_dict = dict_sensor(**kwargs)
     print(sensor_dict)
-    return load_dict(sensor_dict)
+    return load_dict(sensor_dict).expand()[0    ]
 
 
 def test_construct(variant_scalar_rgb):

--- a/src/sensors/tests/test_distant.py
+++ b/src/sensors/tests/test_distant.py
@@ -6,13 +6,16 @@ import mitsuba
 
 
 def dict_sensor(direction=None, target=None, fwidth=1):
-    result = {"type": "distant"}
+    result = {"type": "distant", "target": "circle", "target_radius": 0}
 
     if direction:
         result["direction"] = direction
 
     if target:
-        result["target"] = target
+        result["target_center"] = target
+        result["target"] = "circle"
+    else:
+        result["target_center"] = [0, 0, 0]
 
     result["film"] = {
         "type": "hdrfilm",
@@ -78,7 +81,7 @@ def test_construct(variant_scalar_rgb):
 ])
 @pytest.mark.parametrize("ray_kind", ["regular", "differential"])
 def test_sample_ray(variant_scalar_rgb, direction, target, ray_kind):
-    sensor = make_sensor(direction, target)
+    sensor = make_sensor(direction, target=target)
 
     for (sample1, sample2) in [[[0.32, 0.87], [0.16, 0.44]],
                                [[0.17, 0.44], [0.22, 0.81]],
@@ -105,7 +108,7 @@ def make_scene(direction=[0, 0, -1], target=None):
 
     dict_scene = {
         "type": "scene",
-        "sensor": dict_sensor(direction, target),
+        "sensor": dict_sensor(direction, target=target),
         "surface": {"type": "rectangle"}
     }
 

--- a/src/sensors/tests/test_distant.py
+++ b/src/sensors/tests/test_distant.py
@@ -189,7 +189,6 @@ def test_render(variant_scalar_mono, w_e, w_o, ray_origin):
     l_e = 1.0  # Emitted radiance
     w_e = list(w_e/np.linalg.norm(w_e))  # Emitter direction
     w_o = list(w_o/np.linalg.norm(w_o))  # Sensor direction
-    print(w_o)
     cos_theta_e = abs(ek.dot(w_e, [0, 0, 1]))
     cos_theta_o = abs(ek.dot(w_o, [0, 0, 1]))
 

--- a/src/sensors/tests/test_distant.py
+++ b/src/sensors/tests/test_distant.py
@@ -12,17 +12,17 @@ def dict_sensor(direction=None,
                 ray_origin_a=[0,0,0],
                 ray_origin_b=[0,0,0],
                 fwidth=1):
-    result = {"type": "distant", "ray_origin": "distant"}
+    result = {"type": "distant", "ray_origin_type": "distant"}
 
     if direction:
         result["direction"] = direction
 
     if ray_origin_type == "disk":
-        result["ray_origin"] = ray_origin_type
+        result["ray_origin_type"] = ray_origin_type
         result["ray_origin_center"] = ray_origin_center
         result["ray_origin_radius"] = ray_origin_radius
     elif ray_origin_type =="rectangle":
-        result["ray_origin"] = ray_origin_type
+        result["ray_origin_type"] = ray_origin_type
         result["ray_origin_a"] = ray_origin_a
         result["ray_origin_b"] = ray_origin_b
 
@@ -178,8 +178,8 @@ def test_origin_area(variant_scalar_rgb, origin):
 @pytest.mark.parametrize("w_o", [[0, 0, -1], [0, 1, -1]])
 @pytest.mark.parametrize("ray_origin", [
     {},
-    {"ray_origin": "disk", "ray_origin_center": [0,0,2], "ray_origin_radius": 1},
-    {"ray_origin": "rectangle", "ray_origin_a": [-1,-1,2], "ray_origin_b": [1,1,2]}
+    {"ray_origin_type": "disk", "ray_origin_center": [0,0,2], "ray_origin_radius": 1},
+    {"ray_origin_type": "rectangle", "ray_origin_a": [-1,-1,2], "ray_origin_b": [1,1,2]}
 ])
 def test_render(variant_scalar_mono, w_e, w_o, ray_origin):
     # Test render results with a simple scene
@@ -222,7 +222,7 @@ def test_render(variant_scalar_mono, w_e, w_o, ray_origin):
             },
             "sampler": {
                 "type": "independent",
-                "sample_count": 512
+                "sample_count": 51200
             },
         },
         "integrator": {"type": "path"}
@@ -231,9 +231,9 @@ def test_render(variant_scalar_mono, w_e, w_o, ray_origin):
     # set the sensor origin such that rays hit the square
     if not ray_origin:
         pass
-    elif ray_origin["ray_origin"] == "disk":
+    elif ray_origin["ray_origin_type"] == "disk":
         ray_origin["ray_origin_center"] = [-w_o[i]*2 for i in range(3)]
-    elif ray_origin["ray_origin"] == "rectangle":
+    elif ray_origin["ray_origin_type"] == "rectangle":
         ray_origin["ray_origin_a"] = [-1-w_o[0]*2, -1-w_o[1]*2, 0-w_o[2]*2]
         ray_origin["ray_origin_b"] = [1-w_o[0]*2, 1-w_o[1]*2, 0-w_o[2]*2]
 
@@ -244,9 +244,9 @@ def test_render(variant_scalar_mono, w_e, w_o, ray_origin):
     # the expected recorded radiance has to be corrected
     if not ray_origin:
         ray_origin_area = 2 * np.pi
-    elif ray_origin["ray_origin"] == "disk":
+    elif ray_origin["ray_origin_type"] == "disk":
         ray_origin_area = (ray_origin["ray_origin_radius"]**2) * np.pi
-    elif ray_origin["ray_origin"] =="rectangle":
+    elif ray_origin["ray_origin_type"] =="rectangle":
         ray_origin_a = ray_origin["ray_origin_a"]
         ray_origin_b = ray_origin["ray_origin_b"]
         ray_origin_area = abs(ray_origin_a[0] - ray_origin_b[0]) *  abs(ray_origin_a[1] - ray_origin_b[1])
@@ -259,7 +259,7 @@ def test_render(variant_scalar_mono, w_e, w_o, ray_origin):
     sensor = scene.sensors()[0]
     scene.integrator().render(scene, sensor)
     img = np.array(sensor.film().bitmap()).squeeze()
-    assert np.allclose(np.array(img), expected * ratio, rtol=1e-3)
+    assert np.allclose(np.array(img), expected, rtol=1e-3)
 
 
      


### PR DESCRIPTION
## Description

This PR updates the `distant` sensor to include a parametrizable target area

The area can be described either as a circle with center and radius or as a rectangle through minimum and maximum coordinates. In both cases the area will be parallel to the xy plane.

### Open questions

- The interface needs to be improved. Currently only Point3f objects can be parsed from parameters, not Point2f.
- The sensor needs more tests

## Testing

None yet

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [ ] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [ ] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [ ] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)