### PR TITLE
Updated RPV docs

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -180,3 +180,21 @@
   issn = {0148-0227},
   doi = {10.1029/93JD02072},
 }
+
+@InProceedings{Widlowski2006Rayspread,
+author="Widlowski, Jean-Luc
+and Lavergne, Thomas
+and Pinty, Bernard
+and Verstraete, Michel
+and Gobron, Nadine",
+editor="Graziani, Frank",
+title="Rayspread: A Virtual Laboratory for Rapid BRF Simulations Over 3-D Plant Canopies",
+booktitle="Computational Methods in Transport",
+year="2006",
+publisher="Springer Berlin Heidelberg",
+address="Berlin, Heidelberg",
+pages="211--231",
+abstract="Accurate knowledge of the spatial (and temporal) variability of the biosphere's characteristics is useful not only to address critical scientific issues (climate change, environmental degradation, biodiversity preservation, etc.) but also to provide appropriate initial state and boundary conditions for general circulation or landscape succession models. In particular, the 3-D structure of vegetation emerged as a crucial player in processes affecting carbon sequestration, landscape dynamics and the exchanges of energy, water and trace gases with the atmosphere e.g., [BWG04]. The growth and development of plant architecture, in turn, are primarily conditioned by effective interception of solar radiation that provides the necessary energy for photosynthesis and other physiological processes [VB86].",
+isbn="978-3-540-28125-2"
+}
+

--- a/src/bsdfs/rpv.cpp
+++ b/src/bsdfs/rpv.cpp
@@ -38,19 +38,13 @@ Apart from homogeneous values, the plugin can also accept
 nested or referenced texture maps to be used as the source of parameter
 information, which is then mapped onto the shape based on its UV
 parameterization. When no parameters are specified, the model uses the default
-values of :math:`\rho_0 = 0.1`, :math:`k = 0.1` and :math:`\Theta = 0.0`
+values of :math:`\rho_0 = 0.1`, :math:`k = 0.1` and :math:`g = 0.0`
 
-The model includes several extensions, which introduce up to three optional
-parameters. The following formulae demonstrate these extensions. For the
-fundamental formulae defining the RPV model please refer to the Eradiate
+This plugin also supports the most common extension to four parameters, namely the 
+:math:`\rho_c` extension, as used in :cite:`Widlowski2006Rayspread`.
+
+For the fundamental formulae defining the RPV model please refer to the Eradiate
 Scientific Handbook.
-
-- Parameter :math:`\rho_c`:
-
-  :math:`1+R(G)=1+\frac{1-\rho_c}{1+G}`
-
-  If not given, it defaults to :math:`\rho_0`, yielding the fundamental
-  version of the formula.
 
 Note that this material is one-sided, that is, observed from the
 back side, it will be completely black. If this is undesirable,


### PR DESCRIPTION
## Description

The RPV docs were updated to match the actual implementation.
The docs refer to the parameter `g` everywhere instead of `Theta`.
The docs no longer mention multiple extensions and refer the user to the scientific handbook
for details on the implementation.

The only question is: Is is correct to refer to Raytran in the way I did here?

Fixes eradiate/eradiate-issues#33

## Testing

None

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [ ] ~~My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below~~
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)