### PR TITLE
Fixed two major bugs in the bilambertian BSDF

### DIFF
--- a/src/bsdfs/bilambertian.cpp
+++ b/src/bsdfs/bilambertian.cpp
@@ -74,9 +74,6 @@ public:
         BSDFSample3f bs   = zero<BSDFSample3f>();
         UnpolarizedSpectrum value(0.f);
 
-        // Flip the outgoing direction if the incoming comes from "behind"
-        wo = select(cos_theta_i > 0, wo, Vector3f(wo.x(), wo.y(), -wo.z()));
-
         // Select the lobe to be sampled
         UnpolarizedSpectrum r            = m_reflectance->eval(si, active),
                             t            = m_transmittance->eval(si, active);
@@ -88,7 +85,7 @@ public:
              selected_t = (sample1 >= reflection_sampling_weight) && active;
 
         // Evaluate
-        value = select(active, cos_theta_o, 0.f);
+        value = select(active, Float(1.f), 0.f);
         value[selected_r] *= r;
         value[selected_t] *= t;
 
@@ -105,6 +102,9 @@ public:
             select(selected_r, UInt32(+BSDFFlags::DiffuseReflection),
                    UInt32(+BSDFFlags::DiffuseTransmission));
 
+        // Flip the outgoing direction if the incoming comes from "behind"
+        wo = select(cos_theta_i > 0, wo, Vector3f(wo.x(), wo.y(), -wo.z()));
+        
         // Flip the outgoing direction if transmission was selected
         bs.wo = select(selected_r, wo, Vector3f(wo.x(), wo.y(), -wo.z()));
 

--- a/src/bsdfs/tests/test_bilambertian.py
+++ b/src/bsdfs/tests/test_bilambertian.py
@@ -24,7 +24,9 @@ def test_eval_pdf(variant_scalar_rgb):
     from mitsuba.render import BSDFContext, SurfaceInteraction3f
     from mitsuba.core import Frame3f
 
-    for (r, t) in [(0.2, 0.4), (0.9, 0.1)]:
+    for (r, t) in [(0.2, 0.4), (0.4, 0.2),
+                   (0.1, 0.9), (0.9, 0.1),
+                   (0.4, 0.6), (0.6, 0.4)]:
         albedo = r + t
 
         bsdf = load_dict({
@@ -65,6 +67,10 @@ def test_eval_pdf(variant_scalar_rgb):
 @pytest.mark.parametrize("r,t", [
     [0.6, 0.2],
     [0.2, 0.6],
+    [0.6, 0.4],
+    [0.4, 0.6],
+    [0.9, 0.1],
+    [0.1, 0.9],
     # [1.0, 0.0],  # Fails inexplicably
     [0.0, 1.0],
     # [0.0, 0.0]   # Fails inexplicably


### PR DESCRIPTION
## Description

This PR removes two major bugs in the `bilambertian` BSDF model.

### Incorrect BSDF value for illumination from behind
The BSDF value was computed incorrectly for incoming directions from the back side of the attached shape.
This was due to the fact, that immediately after sampling an outgoing direction, this direction was modified.
The sampling function would only sample a direction in the positive hemisphere (`wo.z >= 0`), which is fine, when
the incoming direction is in this hemisphere as well. This would be the case normally, since BSDFs in Mitsuba are defined to be one sided and valid only for `wi.z >= 0`.
To accommodate radiation coming in from the back side, we simply flip the z-component of the outgoing direction.
That is what happened in line 78 of the old code:
`wo = select(cos_theta_i > 0, wo, Vector3f(wo.x(), wo.y(), -wo.z()));`

The issue arises a few lines later.
First in line 96:
`bs.pdf = select(active, warp::square_to_cosine_hemisphere_pdf(wo), 0.f);`
We compute the PDF value for this outgoing direction. This value will however by negative, since the function does this:
`return math::InvPi<Value> * v.z();`

Further in lines 111 and 112 the bsdf value is set:
` { bs, select(active && bs.pdf > 0.f, Spectrum>(value), 0.f) };`

Here the select query evaluates to `false`, since the pdf's value is negative and the bsdf value is always set to zero.

To mitigate this issue, the inversion of the outgoing direction is pushed further down in the code so that it does not interfere with the computations that are based on the sampled direction.

### Incorrect cosine theta factor

in line 91 we removed the initial setting of the bsdf value to cosine theta_o.

Fixes None

## Testing

I have extended the tests to include more values for the chi_2 test.

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)