### PR TITLE
Docker Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN apt-get install -y ninja-build cmake libc++-9-dev libz-dev libpng-dev libjpeg-dev libxrandr-dev libxinerama-dev libxcursor-dev
+COPY ./builder/build/eradiate-kernel-dist.tar /build/mitsuba/
+
+RUN mkdir -p /build/mistuba /mitsuba && cd /build/mitsuba && tar -xf eradiate-kernel-dist.tar  \
+    && mv dist /mitsuba/dist \
+    && cd / && rm -rf /build
+
+ENV MITSUBA_DIR=/mitsuba
+WORKDIR /app
+
+ENV PYTHONPATH="$MITSUBA_DIR/dist/python:$MITSUBA_DIR/$BUILD_DIR/dist/python:$PYTHONPATH"
+ENV PATH="$MITSUBA_DIR/dist:$MITSUBA_DIR/$BUILD_DIR/dist:$PATH"
+
+CMD mitsuba --help

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:20.04
+
+RUN apt update
+
+RUN DEBIAN_FRONTEND=noninteractive apt install -y   \ 
+    git                                             \
+    cmake                                           \
+    ninja-build                                     \
+    clang-9                                         \
+    libc++-9-dev                                    \
+    libc++abi-9-dev                                 \
+    libpng-dev                                      \
+    zlib1g-dev                                      \
+    python3.9-distutils                             \
+    python3-pip                                     \
+    libjpeg-dev
+
+ENV CC=clang-9
+ENV CXX=clang++-9
+
+CMD git clone --recursive https://github.com/eradiate/eradiate-kernel /sources/eradiate-kernel                         \
+    && mkdir -p /build/eradiate-kernel                                                                                 \
+    && cd /build/eradiate-kernel                                                                                       \
+    && cmake -GNinja -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") /sources/eradiate-kernel    \
+    && ninja                                                                                                           \
+    && tar -cvf eradiate-kernel-dist.tar ./dist

--- a/builder/docker-compose.yml
+++ b/builder/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+
+services:
+  builder:
+    build: .
+    image: "fxia/eradiate-kernel-builder:v1.0.0"
+    volumes:
+      - ./build:/build/eradiate-kernel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+
+services:
+  eradiate-kernel:
+    build: .
+    image: fxia/eradiate-kernel:v1.0.0


### PR DESCRIPTION
## Description

Add the necessary configuration to build 2 different docker image:
 - a toolchain to build the mitsuba renderer
 - the mitsuba renderer itself

These images may be used for other eradiate builds

## Testing

The 2 docker-compose.yml associated with the images allows to launch the compilation and the images to perform some tests with Mitsuba

## Checklist:

- [N/A] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [N/A] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)